### PR TITLE
Fix missing chart rendering

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -198,6 +198,12 @@ async function reloadForInputs() {
   renderSummary('sum-30d', s30);
   renderSummary('sum-all', sall);
 
+  // Charts
+  plotOne('chart-24h', s24, "");
+  plotOne('chart-7d',  s7,  "");
+  plotOne('chart-30d', s30, "");
+  plotOne('chart-all', sall, "");
+
 
 
   // Table activités


### PR DESCRIPTION
## Summary
- Restore chart display by calling `plotOne` for each time range.

## Testing
- `node --check docs/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab5795936c8332a663d126af69004d