### PR TITLE
Afficher les valeurs intermédiaires dans les graphiques

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pour préserver les ressources, l'application réduit la fréquence des requête
 
 - Un compte Supabase et un **projet Supabase** configuré.
 - Les fichiers front-end du projet (fournis dans ce repository) : `index.html`, `styles.css`, `main.js`, `config.example.js` (à renommer), et le présent `README.md`.
-- Le script SQL de création de la base de données Supabase (non fourni ici) contenant les tables de mesures et les fonctions RPC suivantes : `kpis_peaks_range`, `time_series_bucketed`, `peaks_in_range`, `summary_by_tag_range`, `readings_extent`. **Assurez-vous d’avoir ces procédures dans votre base** avec les bonnes définitions (selon votre modèle de données).
+- Le script SQL de création de la base de données Supabase (non fourni ici) contenant les tables de mesures et les fonctions RPC suivantes : `kpis_peaks_range`, `peaks_in_range`, `summary_by_tag_range`, `readings_extent`. **Assurez-vous d’avoir ces procédures dans votre base** avec les bonnes définitions (selon votre modèle de données).
 
 ## Installation et Configuration
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -26,9 +26,12 @@ async function readingsExtent() {
 }
 
 async function series(startISO, endISO) {
-  const { data, error } = await sb.rpc('time_series_bucketed', {
-    start_ts: startISO, end_ts: endISO
-  });
+  const { data, error } = await sb
+    .from('readings')
+    .select('ts, pm1, pm25, pm10')
+    .gte('ts', startISO)
+    .lte('ts', endISO)
+    .order('ts', { ascending: true });
   if (error) throw error;
   return data || [];
 }
@@ -193,7 +196,7 @@ async function reloadForInputs() {
   document.getElementById('kpi-pct').textContent   = (k.pct ?? 0).toFixed(0) + '%';
   setKpiPills(k.pph ?? 0, k.pct ?? 0);
 
-  // Séries pour 4 fenêtres (on réutilise l’agrégat horaire simple)
+  // Séries pour 4 fenêtres (données brutes)
   const nowUtc = dayjs.utc();
   const start24 = nowUtc.subtract(24,'hour');
   const start7  = nowUtc.subtract(7,'day');


### PR DESCRIPTION
## Summary
- Récupération des séries directement depuis la table `readings` pour inclure toutes les mesures, même entre les heures.
- Mise à jour de la documentation pour supprimer la référence à la fonction RPC `time_series_bucketed` devenue inutile.

## Testing
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68acb2a01fa48332b34545c9e1e86860