### PR TITLE
Make peaks list scrollable and sort by recency

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -127,7 +127,7 @@
 
       <div class="card">
         <h3 class="section-title mb-3">Pics détectés</h3>
-        <ul id="list-peaks" class="space-y-2 text-sm"></ul>
+        <ul id="list-peaks" class="space-y-2 text-sm max-h-64 overflow-y-auto"></ul>
       </div>
     </section>
   </main>

--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,7 @@
 
       <div class="card">
         <h3 class="section-title mb-3">Pics détectés</h3>
-        <ul id="list-peaks" class="space-y-2 text-sm"></ul>
+        <ul id="list-peaks" class="space-y-2 text-sm max-h-64 overflow-y-auto"></ul>
       </div>
     </section>
   </main>

--- a/docs/main.js
+++ b/docs/main.js
@@ -240,6 +240,7 @@ async function reloadForInputs() {
 
   // Liste des pics
   const peaks = await peaksList(startISO, endISO);
+  peaks.sort((a, b) => new Date(b.ts) - new Date(a.ts));
   const ul = document.getElementById('list-peaks');
   ul.innerHTML = '';
   peaks.forEach(p=>{


### PR DESCRIPTION
## Summary
- Limit detected peaks list height and allow vertical scrolling
- Show most recent peaks first in the list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acb545efb88332bcc98106559c7126