### PR TITLE
Use last_readings RPC for series retrieval

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -25,13 +25,8 @@ async function readingsExtent() {
   return { min: row.min_ts, max: row.max_ts };
 }
 
-async function series(startISO, endISO) {
-  const { data, error } = await sb
-    .from('readings')
-    .select('ts, pm1, pm25, pm10')
-    .gte('ts', startISO)
-    .lte('ts', endISO)
-    .order('ts', { ascending: true });
+async function series() {
+  const { data, error } = await sb.rpc('last_readings', { limit_n: 100 });
   if (error) throw error;
   return data || [];
 }


### PR DESCRIPTION
## Summary
- fetch reading series using `last_readings` RPC

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b19c575ae883329da37e713a832126