### PR TITLE
Fix range queries for chart data

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -25,8 +25,13 @@ async function readingsExtent() {
   return { min: row.min_ts, max: row.max_ts };
 }
 
-async function series(_startISO, _endISO) {
-  const { data, error } = await sb.rpc('last_readings', { limit_n: 100 });
+async function series(startISO, endISO) {
+  const { data, error } = await sb
+    .from('readings')
+    .select('ts, pm1, pm25, pm10')
+    .gte('ts', startISO)
+    .lte('ts', endISO)
+    .order('ts');
   if (error) throw error;
   return data || [];
 }


### PR DESCRIPTION
## Summary
- Retrieve readings from Supabase using provided start and end timestamps
- Show correct data when switching between 24h, 7d, 30d and all ranges

## Testing
- `node --check docs/main.js`
- `npm test` (fails: missing script 'test')

------
https://chatgpt.com/codex/tasks/task_e_68c8015c77b48332b9e5ecdea5124caf