### PR TITLE
Fix initial data load throttle

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -251,7 +251,9 @@ async function loadAll() {
   });
   setActiveRange(currentRange);
 
-  await reloadThrottled();
+  await reloadForInputs();
+  // Allow an immediate manual refresh by backdating lastReload
+  lastReload = Date.now() - MIN_INTERVAL_MS;
 }
 
 async function reloadForInputs() {


### PR DESCRIPTION
## Summary
- Call `reloadForInputs` on initial load to avoid unintended throttle
- Backdate `lastReload` so the first manual refresh is allowed immediately

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8055defe08332aab36ed42bb60498