### PR TITLE
Fix chart data loading from selected range

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -25,8 +25,13 @@ async function readingsExtent() {
   return { min: row.min_ts, max: row.max_ts };
 }
 
-async function series(_startISO, _endISO) {
-  const { data, error } = await sb.rpc('last_readings');
+async function series(startISO, endISO) {
+  const { data, error } = await sb
+    .from('readings')
+    .select('ts, pm1, pm25, pm10')
+    .gte('ts', startISO)
+    .lte('ts', endISO)
+    .order('ts');
   if (error) throw error;
   return data || [];
 }


### PR DESCRIPTION
## Summary
- Query readings table using selected date range instead of last_readings RPC

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80ca6bff08332b10988e0b5754756