### PR TITLE
Increase ingestion batch limit

### DIFF
--- a/docs/functions/ingest/index.ts
+++ b/docs/functions/ingest/index.ts
@@ -93,8 +93,8 @@ function validateRequest(body: any): { valid: boolean; errors: string[]; data?: 
       errors.push('Points array cannot be empty');
     }
     
-    if (body.points.length > 100) {
-      errors.push('Too many points (max 100 per request)');
+    if (body.points.length > 10000) {
+      errors.push('Too many points (max 10000 per request)');
     }
     
     // Validate each point


### PR DESCRIPTION
## Summary
- Allow ingest RPC to accept up to 10,000 points per request instead of 100

## Testing
- `npx tsc --noEmit docs/functions/ingest/index.ts` *(fails: Cannot find module 'https://deno.land/...')*
- `deno lint docs/functions/ingest/index.ts` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81302f84883329ff58ea8abbea365