### PR TITLE
Refine dashboard layout and styling

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Qualité de l’air — Atelier</title>
-   <link rel="icon" href="favicon-96X96.png" type="image/png" />
+  <link rel="icon" href="favicon-96X96.png" type="image/png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Manrope:wght@500;600&display=swap"
+    rel="stylesheet"
+  />
   
   <!-- Tailwind (CDN) -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -30,85 +36,126 @@
 
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body class="min-h-screen"> <!-- fond neutre -->
+<body class="min-h-screen">
 
   <!-- Header -->
-  <header class="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
-    <div class="flex items-center gap-3">
-      <div class="h-9 w-9 rounded-2xl bg-primary/90 grid place-items-center text-white font-bold">AQ</div>
-      <h1 class="text-xl font-semibold text-text">Tableau de bord — Qualité de l’air</h1>
+  <header class="layout-container py-6 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+    <div class="flex items-center gap-4">
+      <div class="h-12 w-12 rounded-2xl bg-primary grid place-items-center text-white text-lg font-semibold tracking-tight">
+        AQ
+      </div>
+      <h1 class="text-balance">Tableau de bord — Qualité de l’air</h1>
     </div>
 
-    <div class="flex items-center gap-3">
-      <div class="text-sm text-secondary">Période</div>
+    <div class="flex flex-wrap items-center gap-4 md:gap-6">
+      <span class="text-caption">Période</span>
       <input id="from" type="date" class="tw-input" />
       <span class="text-secondary">–</span>
       <input id="to" type="date" class="tw-input" />
-      <button id="apply" class="tw-btn-primary">Appliquer</button>
-      <button id="reset" class="tw-btn-outline">Réinitialiser</button>
+      <button id="apply" class="tw-btn tw-btn-primary">Appliquer</button>
+      <button id="reset" class="tw-btn tw-btn-outline">Réinitialiser</button>
     </div>
   </header>
 
-  <main class="max-w-7xl mx-auto px-4 pb-12 space-y-8">
+  <main class="layout-container pb-16 space-y-10">
 
     <!-- KPIs (placeholder simples, on garde la logique en place) -->
-    <section class="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="card">
-        <div class="text-sm text-secondary mb-1">Pics détectés</div>
-        <div id="kpi-peaks" class="text-3xl font-semibold tabular-nums text-text">–</div>
-      </div>
-      <div class="card">
-        <div class="text-sm text-secondary mb-1">Dernière mesure</div>
-        <div class="flex items-center gap-2">
-          <div id="kpi-last" class="text-3xl font-semibold tabular-nums text-text">–</div>
-          <span id="kpi-last-arrow" class="text-3xl"></span>
+    <section class="grid gap-6 md:grid-cols-12">
+      <div class="card kpi-card md:col-span-4">
+        <div class="kpi-header">
+          <p class="kpi-label">Pics détectés</p>
+          <span class="kpi-icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4 16.5L9.5 11L13 14.5L20 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M20 12V7H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
         </div>
-        <div id="kpi-last-time" class="text-sm text-secondary mt-1">–</div>
-      </div>
-      <div class="card">
-        <div class="text-sm text-secondary mb-1">% du temps &gt; 15 µg/m³</div>
-        <div class="flex items-center gap-2">
-          <div id="kpi-pct" class="text-3xl font-semibold tabular-nums text-text">–</div>
-          <span id="kpi-pct-pill" class="badge">—</span>
+        <div class="kpi-metric">
+          <div class="kpi-value-wrap">
+            <span id="kpi-peaks" class="kpi-value tabular-nums">–</span>
+          </div>
         </div>
+        <p class="kpi-sub">Total de pics sur la période</p>
+      </div>
+
+      <div class="card kpi-card md:col-span-4">
+        <div class="kpi-header">
+          <p class="kpi-label">Dernière mesure PM2.5</p>
+          <span class="kpi-icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 3V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              <path d="M6 8L9 5L12 8L15 5L18 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+        </div>
+        <div class="kpi-metric">
+          <div class="kpi-value-wrap">
+            <span id="kpi-last" class="kpi-value tabular-nums">–</span>
+            <span class="kpi-unit">µg/m³</span>
+          </div>
+          <span id="kpi-last-arrow" class="kpi-trend-icon" aria-hidden="true"></span>
+        </div>
+        <p id="kpi-last-time" class="kpi-sub">–</p>
+      </div>
+
+      <div class="card kpi-card md:col-span-4">
+        <div class="kpi-header">
+          <p class="kpi-label">Temps &gt; 15 µg/m³</p>
+          <span class="kpi-icon" aria-hidden="true">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M5 19H19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              <path d="M7 16L11.5 7.5L14.5 13L17 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+        </div>
+        <div class="kpi-metric">
+          <div class="kpi-value-wrap">
+            <span id="kpi-pct" class="kpi-value tabular-nums">–</span>
+          </div>
+          <span id="kpi-pct-pill" class="status-pill">—</span>
+        </div>
+        <p class="kpi-sub">Part de la période au-dessus du seuil OMS</p>
       </div>
     </section>
 
     <!-- Trend (single chart with range buttons) -->
     <section class="card">
-      <div class="flex items-center justify-between mb-2">
+      <div class="section-header">
         <h2 id="chart-title" class="section-title">Aujourd’hui (24 h)</h2>
         <div class="summary-pills" id="chart-summary"></div>
       </div>
       <div id="chart-main" class="h-72"></div>
-      <div class="flex justify-center gap-2 mt-4">
-        <button class="tw-btn-primary" data-range="24h">24 h</button>
-        <button class="tw-btn-outline" data-range="7d">7 derniers jours</button>
-        <button class="tw-btn-outline" data-range="30d">30 derniers jours</button>
-        <button class="tw-btn-outline" data-range="all">Depuis toujours</button>
+      <div class="button-bar">
+        <button class="tw-btn tw-btn-primary" data-range="24h">24 h</button>
+        <button class="tw-btn tw-btn-outline" data-range="7d">7 derniers jours</button>
+        <button class="tw-btn tw-btn-outline" data-range="30d">30 derniers jours</button>
+        <button class="tw-btn tw-btn-outline" data-range="all">Depuis toujours</button>
       </div>
     </section>
 
     <!-- Table + Pics (structure légère) -->
-    <section class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      <div class="card overflow-x-auto">
-        <h3 class="section-title mb-3">Activités → Risque</h3>
-        <table class="min-w-full table-zebra text-sm">
-          <thead class="sticky top-0 bg-white">
-            <tr class="text-left text-secondary">
-              <th class="py-2 pr-4">Hashtag</th>
-              <th class="py-2 px-4 text-right">Heures</th>
-              <th class="py-2 px-4 text-right">Pics</th>
-              <th class="py-2 pl-4 text-right">Pics/h</th>
-            </tr>
-          </thead>
-          <tbody id="tbl-acts"></tbody>
-        </table>
+    <section class="grid gap-6 lg:grid-cols-12">
+      <div class="card overflow-hidden lg:col-span-7">
+        <h3 class="section-title mb-4">Activités → Risque</h3>
+        <div class="table-scroll">
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th class="text-left">Hashtag</th>
+                <th class="text-right">Heures</th>
+                <th class="text-right">Pics</th>
+                <th class="text-right">Pics/h</th>
+              </tr>
+            </thead>
+            <tbody id="tbl-acts"></tbody>
+          </table>
+        </div>
       </div>
 
-      <div class="card">
-        <h3 class="section-title mb-3">Pics détectés</h3>
-        <ul id="list-peaks" class="space-y-2 text-sm max-h-64 overflow-y-auto"></ul>
+      <div class="card lg:col-span-5">
+        <h3 class="section-title mb-4">Pics détectés</h3>
+        <ul id="list-peaks" class="stacked-list"></ul>
       </div>
     </section>
   </main>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,71 +1,432 @@
 /* Design tokens */
-:root{
-  --primary:#E11D48;           /* rouge principal */
-  --primary-hover:#BE123C;     /* hover du bouton primaire */
-  --text:#0F172A;              /* couleur du texte */
-  --secondary:#475569;         /* texte secondaire */
-  --background:#F8FAFC;        /* fond de l'app */
-  --panel:#FFFFFF;             /* panneaux / cartes */
-  --border:#E5E7EB;            /* bordures */
-  --success:#10B981;           /* états */
-  --warning:#F59E0B;
-  --danger:#EF4444;
+:root {
+  --primary: #E11D48;
+  --primary-hover: #BE123C;
+  --text: #0F172A;
+  --secondary: #475569;
+  --caption: #94A3B8;
+  --background: #F8FAFC;
+  --surface-soft: #F1F5F9;
+  --panel: #FFFFFF;
+  --border: #E5E7EB;
+  --success: #047857;
+  --warning: #B45309;
+  --danger: #B91C1C;
+  --shadow-soft: 0 24px 48px -32px rgba(15, 23, 42, 0.45);
 }
 
-body{ color:var(--text); background:var(--background); font-family: ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif; }
-.tabular-nums{ font-variant-numeric: tabular-nums; font-feature-settings:"tnum"; }
-
-.card{
-  background:var(--panel);
-  border:1px solid var(--border);
-  border-radius:1rem;
-  box-shadow:0 1px 2px rgba(0,0,0,.04);
-  padding:1rem;
+body {
+  color: var(--text);
+  background: var(--background);
+  font-family: 'Inter', 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: 'liga' 1, 'kern' 1;
 }
 
-.section-title{ font-weight:600; color:var(--text); }
-
-.tw-input{
-  border:1px solid var(--border);
-  background:#fff;
-  padding:.4rem .6rem;
-  border-radius:.6rem;
-  font-size:.875rem;
-}
-.tw-input:focus{ outline:2px solid var(--primary); outline-offset:0; }
-
-.tw-btn-primary{
-  background:var(--primary);
-  color:#fff;
-  padding:.45rem .8rem;
-  border-radius:.7rem;
-  font-weight:600;
-}
-.tw-btn-primary:hover{ background:var(--primary-hover); }
-
-.tw-btn-outline{
-  border:1px solid var(--primary);
-  color:var(--primary);
-  padding:.45rem .8rem;
-  border-radius:.7rem;
-  font-weight:600;
-  background:#fff;
+h1,
+h2,
+h3 {
+  color: var(--text);
+  letter-spacing: -0.01em;
 }
 
-.badge{
-  display:inline-flex; align-items:center; gap:.35rem;
-  padding:.15rem .5rem; border-radius:999px; font-size:.75rem; font-weight:700;
-  border:1px solid var(--border); background:var(--panel); color:var(--secondary);
+h1 {
+  font-size: clamp(26px, 2.6vw, 28px);
+  font-weight: 600;
 }
-.badge.ok{ background:var(--success); color:#FFFFFF; border-color:var(--success); }
-.badge.warn{ background:var(--warning); color:#FFFFFF; border-color:var(--warning); }
-.badge.risk{ background:var(--danger); color:#FFFFFF; border-color:var(--danger); }
 
-.table-zebra tbody tr:nth-child(even){ background:var(--background); }
+h2 {
+  font-size: 20px;
+  font-weight: 600;
+}
 
-/* petites puces sous les titres */
-.summary-pills{ display:flex; gap:.4rem; flex-wrap:wrap; }
-.summary-pills .chip{
-  font-size:.72rem; font-weight:600; border:1px solid var(--border);
-  padding:.2rem .5rem; border-radius:999px; background:var(--panel);
+h3 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.text-balance {
+  text-wrap: balance;
+}
+
+.tabular-nums {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum';
+}
+
+.layout-container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+@media (min-width: 1280px) {
+  .layout-container {
+    max-width: 1280px;
+  }
+}
+
+@media (max-width: 640px) {
+  .layout-container {
+    padding: 0 20px;
+  }
+}
+
+.text-caption {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--caption);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.kpi-card {
+  min-height: 140px;
+  justify-content: space-between;
+}
+
+.kpi-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.kpi-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--caption);
+}
+
+.kpi-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: var(--surface-soft);
+  color: var(--secondary);
+}
+
+.kpi-metric {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.kpi-value-wrap {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.kpi-value {
+  font-size: 3.5rem;
+  line-height: 1;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.kpi-unit {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--secondary);
+  margin-bottom: 8px;
+}
+
+.kpi-sub {
+  margin-top: 8px;
+  font-size: 0.75rem;
+  color: var(--secondary);
+  letter-spacing: 0.02em;
+}
+
+.kpi-trend-icon {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--secondary);
+  min-width: 1.5rem;
+  text-align: right;
+}
+
+.kpi-trend-icon.is-up {
+  color: var(--success);
+}
+
+.kpi-trend-icon.is-down {
+  color: var(--danger);
+}
+
+.kpi-trend-icon.is-flat {
+  color: var(--secondary);
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 8px;
+}
+
+.section-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.summary-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.summary-pills .chip {
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  padding: 8px 16px;
+  border-radius: 12px;
+  background: var(--surface-soft);
+  color: var(--secondary);
+  letter-spacing: 0.04em;
+}
+
+.button-bar {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+}
+
+.tw-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  padding: 0 24px;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
+  cursor: pointer;
+}
+
+.tw-btn:focus-visible {
+  outline: 2px solid rgba(225, 29, 72, 0.32);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px rgba(225, 29, 72, 0.18);
+}
+
+.tw-btn-primary {
+  background: var(--primary);
+  color: #FFFFFF;
+}
+
+.tw-btn-primary:hover {
+  background: var(--primary-hover);
+}
+
+.tw-btn-primary:active {
+  background: #9F1239;
+}
+
+.tw-btn-outline {
+  background: transparent;
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.tw-btn-outline:hover {
+  background: rgba(225, 29, 72, 0.08);
+}
+
+.tw-btn-outline:active {
+  background: rgba(225, 29, 72, 0.12);
+}
+
+.tw-btn-ghost {
+  background: transparent;
+  color: var(--secondary);
+}
+
+.tw-btn-ghost:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.tw-input {
+  height: 44px;
+  border: 1px solid var(--border);
+  background: #FFFFFF;
+  padding: 0 16px;
+  border-radius: 12px;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: var(--text);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.tw-input:focus-visible {
+  border-color: var(--primary);
+  outline: 2px solid rgba(225, 29, 72, 0.26);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(225, 29, 72, 0.12);
+}
+
+.tw-input::-webkit-calendar-picker-indicator {
+  filter: brightness(0.3);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 16px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--secondary);
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+}
+
+.status-pill--ok {
+  color: #047857;
+  background: rgba(4, 120, 87, 0.16);
+  border-color: rgba(4, 120, 87, 0.32);
+}
+
+.status-pill--warn {
+  color: #B45309;
+  background: rgba(217, 119, 6, 0.18);
+  border-color: rgba(217, 119, 6, 0.36);
+}
+
+.status-pill--risk {
+  color: #B91C1C;
+  background: rgba(220, 38, 38, 0.18);
+  border-color: rgba(220, 38, 38, 0.36);
+}
+
+.table-scroll {
+  overflow: auto;
+  max-height: 320px;
+  padding-right: 8px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.9375rem;
+}
+
+.table-scroll .data-table {
+  min-width: 100%;
+}
+
+.data-table thead th {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--caption);
+  padding: 0 16px 16px 0;
+  background: var(--panel);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.data-table tbody td {
+  padding: 16px 16px 16px 0;
+  border-top: 1px solid var(--border);
+  color: var(--text);
+}
+
+.data-table tbody td:first-child {
+  font-weight: 600;
+}
+
+.data-table thead th:last-child,
+.data-table tbody td:last-child {
+  padding-right: 0;
+}
+
+.data-table tbody tr:hover td {
+  background: rgba(15, 23, 42, 0.02);
+}
+
+.stacked-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 256px;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.stacked-list li {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 16px;
+  color: var(--text);
+  font-size: 0.9375rem;
+}
+
+.stacked-list li:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.stacked-list .dot {
+  width: 6px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--primary);
+  flex-shrink: 0;
+}
+
+.stacked-list .value {
+  margin-left: auto;
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.stacked-list time {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary
- adopt a crisp Inter/Manrope typographic system and update the dashboard layout to a 12-column container
- redesign KPI cards, controls, and buttons with consistent spacing, contrast, and feedback states
- refresh table and peaks list presentations for clearer hierarchy and rhythm

## Testing
- n/a (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68c83f38902c8332bcdb881b0d1f2b6a