### PR TITLE
Improve page side spacing

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -60,7 +60,8 @@ h3 {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding-block: 0;
+  padding-inline: clamp(20px, 4vw, 48px);
 }
 
 @media (min-width: 1280px) {
@@ -71,7 +72,7 @@ h3 {
 
 @media (max-width: 640px) {
   .layout-container {
-    padding: 0 20px;
+    padding-inline: 20px;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the shared layout container spacing to restore horizontal margins
- keep the mobile padding unchanged to avoid regressions on small screens

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68c843aa3d348332a1183621d88f1700