### PR TITLE
Remove manual period picker from dashboard header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,14 +47,6 @@
       <h1 class="text-balance">Tableau de bord — Qualité de l’air</h1>
     </div>
 
-    <div class="flex flex-wrap items-center gap-4 md:gap-6">
-      <span class="text-caption">Période</span>
-      <input id="from" type="date" class="tw-input" />
-      <span class="text-secondary">–</span>
-      <input id="to" type="date" class="tw-input" />
-      <button id="apply" class="tw-btn tw-btn-primary">Appliquer</button>
-      <button id="reset" class="tw-btn tw-btn-outline">Réinitialiser</button>
-    </div>
   </header>
 
   <main class="layout-container pb-16 space-y-10">


### PR DESCRIPTION
## Summary
- remove the unused period selector block from the dashboard header markup
- compute the dashboard reporting window from the latest data instead of reading form inputs
- guard refresh logic when the readings extent is unavailable and reuse it for cached ranges

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68c8526bc934833284be9fd077f926d9