### PR TITLE
Fix PM2.5 KPI display details

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -76,8 +76,9 @@
           <p class="kpi-label">Dernière mesure PM2.5</p>
           <span class="kpi-icon" aria-hidden="true">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 3V21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-              <path d="M6 8L9 5L12 8L15 5L18 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 16.5a7 7 0 1 1 14 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+              <path d="M12 12l3-4.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              <circle cx="12" cy="12" r="1.25" fill="currentColor"/>
             </svg>
           </span>
         </div>

--- a/docs/main.js
+++ b/docs/main.js
@@ -297,7 +297,7 @@ async function reloadDashboard() {
         arrowEl.textContent = '▼';
         arrowEl.className = 'kpi-trend-icon is-down';
       } else {
-        arrowEl.textContent = '→';
+        arrowEl.textContent = '=';
         arrowEl.className = 'kpi-trend-icon is-flat';
       }
     } else {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -148,7 +148,6 @@ h3 {
 
 .kpi-unit {
   font-size: 0.75rem;
-  text-transform: uppercase;
   letter-spacing: 0.16em;
   color: var(--secondary);
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary
- replace the PM2.5 KPI card icon with a gauge-style pictogram
- keep the µg/m³ unit readable by removing the uppercase transform
- show an equals sign when the latest PM2.5 value matches the previous reading

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c857936b9483329ec8230e7c162c3a