### PR TITLE
Refine typography for dashboard hierarchy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Manrope:wght@500;600&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap"
     rel="stylesheet"
   />
   

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -18,7 +18,7 @@
 body {
   color: var(--text);
   background: var(--background);
-  font-family: 'Inter', 'Manrope', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   font-size: 16px;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
@@ -30,6 +30,7 @@ h2,
 h3 {
   color: var(--text);
   letter-spacing: -0.01em;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
 }
 
 h1 {
@@ -79,8 +80,7 @@ h3 {
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--caption);
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .card {
@@ -109,8 +109,7 @@ h3 {
 .kpi-label {
   font-size: 0.75rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.04em;
   color: var(--caption);
 }
 
@@ -194,6 +193,7 @@ h3 {
   font-size: 20px;
   font-weight: 600;
   color: var(--text);
+  font-family: 'Playfair Display', 'Times New Roman', serif;
 }
 
 .summary-pills {
@@ -309,8 +309,7 @@ h3 {
   border-radius: 12px;
   font-size: 0.75rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.08em;
   color: var(--secondary);
   background: var(--surface-soft);
   border: 1px solid var(--border);
@@ -354,8 +353,7 @@ h3 {
 .data-table thead th {
   font-size: 0.75rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.06em;
   color: var(--caption);
   padding: 0 16px 16px 0;
   background: var(--panel);
@@ -427,5 +425,4 @@ h3 {
   font-weight: 500;
   color: var(--secondary);
   letter-spacing: 0.08em;
-  text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary
- load Playfair Display alongside Inter to introduce a refined serif voice for page titles
- adjust the CSS hierarchy so headings use the serif family while body text stays in a clean sans-serif
- remove uppercase transformations and rebalance spacing on labels, table headers, and pills to keep natural casing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c85c84029483329a53c42d2f8081f1