### PR TITLE
Update dashboard French copy

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -35,7 +35,7 @@
   <header class="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
     <div class="flex items-center gap-3">
       <div class="h-9 w-9 rounded-2xl bg-primary/90 grid place-items-center text-white font-bold">AQ</div>
-      <h1 class="text-xl font-semibold text-text">Tableau de bord — Qualité de l’air</h1>
+      <h1 class="text-xl font-semibold text-text">Qualité de l’air</h1>
     </div>
 
     <div class="flex items-center gap-3">
@@ -57,7 +57,7 @@
         <div id="kpi-peaks" class="text-3xl font-semibold tabular-nums text-text">–</div>
       </div>
       <div class="card">
-        <div class="text-sm text-secondary mb-1">Dernière mesure</div>
+        <div class="text-sm text-secondary mb-1">PM₂.₅ actuel</div>
         <div class="flex items-center gap-2">
           <div id="kpi-last" class="text-3xl font-semibold tabular-nums text-text">–</div>
           <span id="kpi-last-arrow" class="text-3xl"></span>
@@ -65,7 +65,7 @@
         <div id="kpi-last-time" class="text-sm text-secondary mt-1">–</div>
       </div>
       <div class="card">
-        <div class="text-sm text-secondary mb-1">% du temps &gt; 15 µg/m³</div>
+        <div class="text-sm text-secondary mb-1">Temps au-dessus du seuil</div>
         <div class="flex items-center gap-2">
           <div id="kpi-pct" class="text-3xl font-semibold tabular-nums text-text">–</div>
           <span id="kpi-pct-pill" class="badge">—</span>
@@ -77,7 +77,7 @@
     <section class="grid grid-cols-1 xl:grid-cols-2 gap-6">
       <div class="card">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="section-title">Aujourd’hui (24 h)</h2>
+          <h2 class="section-title">Aujourd’hui (24 h)</h2>
           <div class="summary-pills" id="sum-24h"></div>
         </div>
         <div id="chart-24h" class="h-72"></div>
@@ -85,7 +85,7 @@
 
       <div class="card">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="section-title">7 derniers jours</h2>
+          <h2 class="section-title">7 jours</h2>
           <div class="summary-pills" id="sum-7d"></div>
         </div>
         <div id="chart-7d" class="h-72"></div>
@@ -93,7 +93,7 @@
 
       <div class="card">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="section-title">30 derniers jours</h2>
+          <h2 class="section-title">30 jours</h2>
           <div class="summary-pills" id="sum-30d"></div>
         </div>
         <div id="chart-30d" class="h-72"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
       <div class="h-12 w-12 rounded-2xl bg-primary grid place-items-center text-white text-lg font-semibold tracking-tight">
         AQ
       </div>
-      <h1 class="text-balance">Tableau de bord — Qualité de l’air</h1>
+      <h1 class="text-balance">Qualité de l’air</h1>
     </div>
 
   </header>
@@ -68,12 +68,12 @@
             <span id="kpi-peaks" class="kpi-value tabular-nums">–</span>
           </div>
         </div>
-        <p class="kpi-sub">Total de pics sur la période</p>
+        <p class="kpi-sub">Total sur la période</p>
       </div>
 
       <div class="card kpi-card md:col-span-4">
         <div class="kpi-header">
-          <p class="kpi-label">Dernière mesure PM2.5</p>
+          <p class="kpi-label">PM₂.₅ actuel</p>
           <span class="kpi-icon" aria-hidden="true">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M5 16.5a7 7 0 1 1 14 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -94,7 +94,7 @@
 
       <div class="card kpi-card md:col-span-4">
         <div class="kpi-header">
-          <p class="kpi-label">Temps &gt; 15 µg/m³</p>
+          <p class="kpi-label">Temps au-dessus du seuil</p>
           <span class="kpi-icon" aria-hidden="true">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M5 19H19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -108,22 +108,22 @@
           </div>
           <span id="kpi-pct-pill" class="status-pill">—</span>
         </div>
-        <p class="kpi-sub">Part de la période au-dessus du seuil OMS</p>
+        <p class="kpi-sub">Part au-dessus du seuil OMS</p>
       </div>
     </section>
 
     <!-- Trend (single chart with range buttons) -->
     <section class="card">
       <div class="section-header">
-        <h2 id="chart-title" class="section-title">Aujourd’hui (24 h)</h2>
+        <h2 id="chart-title" class="section-title">Aujourd’hui (24 h)</h2>
         <div class="summary-pills" id="chart-summary"></div>
       </div>
       <div id="chart-main" class="h-72"></div>
       <div class="button-bar">
-        <button class="tw-btn tw-btn-primary" data-range="24h">24 h</button>
-        <button class="tw-btn tw-btn-outline" data-range="7d">7 derniers jours</button>
-        <button class="tw-btn tw-btn-outline" data-range="30d">30 derniers jours</button>
-        <button class="tw-btn tw-btn-outline" data-range="all">Depuis toujours</button>
+        <button class="tw-btn tw-btn-primary" data-range="24h">24 h</button>
+        <button class="tw-btn tw-btn-outline" data-range="7d">7 jours</button>
+        <button class="tw-btn tw-btn-outline" data-range="30d">30 jours</button>
+        <button class="tw-btn tw-btn-outline" data-range="all">Depuis le début</button>
       </div>
     </section>
 

--- a/docs/main.js
+++ b/docs/main.js
@@ -113,8 +113,8 @@ function renderSummary(id, serie) {
   }
   const above = serie.filter(r => (r.pm25 ?? 0) > WHO_LINE).length;
   const max25 = Math.max(...serie.map(r => r.pm25 ?? 0));
-  wrap.appendChild(chip(`Pics (PM2.5>15) : ${above}`));
-  wrap.appendChild(chip(`Max PM2.5 : ${Math.round(max25)} µg/m³`));
+  wrap.appendChild(chip(`Pics au-dessus du seuil : ${above}`));
+  wrap.appendChild(chip(`PM₂.₅ maximum : ${Math.round(max25)} µg/m³`));
 }
 
 function plotOne(containerId, serie, title, xRange) {
@@ -127,9 +127,9 @@ function plotOne(containerId, serie, title, xRange) {
   const y10= serie.map(r => r.pm10 != null ? Math.round(r.pm10) : null);
 
   const traces = [
-    { name:'PM2.5', x, y: y25, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm25 } },
-    { name:'PM10',  x, y: y10, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm10 } },
-    { name:'PM1',   x, y: y1,  mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm1  } },
+    { name:'PM₂.₅', x, y: y25, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm25 } },
+    { name:'PM₁₀',  x, y: y10, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm10 } },
+    { name:'PM₁',   x, y: y1,  mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm1  } },
   ];
 
   const allVals = [...y1, ...y25, ...y10].filter(v => v != null);
@@ -204,9 +204,9 @@ function plotOne(containerId, serie, title, xRange) {
 }
 
 const RANGE_TITLES = {
-  '24h': 'Aujourd’hui (24 h)',
-  '7d': '7 derniers jours',
-  '30d': '30 derniers jours',
+  '24h': 'Aujourd’hui (24 h)',
+  '7d': '7 jours',
+  '30d': '30 jours',
   'all': 'Depuis le début'
 };
 let currentRange = '24h';
@@ -285,8 +285,9 @@ async function reloadDashboard() {
   if (lastVal) {
     const val = lastVal.pm25 != null ? Math.round(lastVal.pm25) : null;
     valEl.textContent = val != null ? val.toString() : '–';
-    const measuredAt = dayjs(lastVal.ts).tz(tz).format('HH:mm');
-    timeEl.textContent = `Relevé à ${measuredAt}`;
+    const measuredAt = dayjs(lastVal.ts).tz(tz);
+    const measuredAtStr = measuredAt.format('HH:mm').replace(':', ' h ');
+    timeEl.textContent = `µg/m³ à ${measuredAtStr}`;
 
     if (prevVal && prevVal.pm25 != null && val != null) {
       const prev = Math.round(prevVal.pm25);


### PR DESCRIPTION
## Summary
- replace dashboard headers and KPI subtitles with the requested French wording on the main and fallback pages
- update period button labels and chart titles to the new phrases with thin spaces
- adjust chart legend labels, summary chips, and the PM₂.₅ timestamp helper to match the revised copy

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c85ea0f3e08332bbab3787f9526318