### PR TITLE
Apply reference palette to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,3 @@
-# MVP – Analyse de la Qualité de l’Air (Atelier de Céramique)
+# Analyse de la qualité de l’air (Atelier)
 
-Ce projet est un **MVP (Minimum Viable Product)** de tableau de bord pour analyser la qualité de l’air dans un atelier de céramique. Il s’agit d’une application web 100% statique (HTML/JS/CSS) qui interroge une base de données **Supabase** via des procédures stockées (RPC) sécurisées. L’interface est monopage, responsive, et conforme à la charte graphique définie.
-
-## Fonctionnalités
-
-- **Indicateurs clés (KPI)** – Affiche trois indicateurs calculés sur la période sélectionnée : le nombre total de pics de pollution, le nombre de pics par heure, et le pourcentage du temps où la concentration de particules PM2.5 dépasse 15 µg/m³. Chaque indicateur est accompagné d’une pastille de couleur avec icône (vert, jaune ou rouge) indiquant l’état : vert = bon, jaune = moyen, rouge = mauvais (selon des seuils paramétrés).
-- **Graphiques temporels** – Montre l’évolution des concentrations de particules fines **PM1**, **PM2.5** et **PM10** au cours du temps, sous forme de courbes. Chaque graphique correspond à une mesure (PM1, PM2.5, PM10) et se met à jour dynamiquement en fonction de la plage de dates sélectionnée. Les graphiques utilisent Plotly et offrent des interactions natives : info-bulles au survol, zoom/dézoom (sélectionner une zone ou utiliser les contrôles), et redéfinition de l’échelle temporelle.
-- **Tableau des activités** – Pour chaque activité enregistrée dans l’atelier (étiquetée dans les données), affiche la durée totale pendant la période choisie, le nombre de pics survenus durant cette activité, et le ratio de pics par heure. Ce tableau permet d’identifier quelles activités sont associées à davantage de pics de pollution.
-- **Liste des pics** – Liste chronologique de tous les **pics de pollution** détectés pendant la plage de dates sélectionnée (dépassements du seuil de 15 µg/m³ en PM2.5). Pour chaque pic, on affiche la date/heure (heure de Paris) et la valeur mesurée (µg/m³). Cela permet de consulter le détail des événements de pollution et de les rapprocher éventuellement des activités en cours.
-
-## Limitation des appels à la base de données
-
-Pour préserver les ressources, l'application réduit la fréquence des requêtes :
-
-- En affichage passif, un rafraîchissement automatique est réalisé toutes les 4 minutes (≈15 appels/h).
-- Lors de l'exploration manuelle, un garde-fou limite les rafraîchissements à une fois toutes les 2 minutes (≤30 appels/h).
-
-## Prérequis
-
-- Un compte Supabase et un **projet Supabase** configuré.
-- Les fichiers front-end du projet (fournis dans ce repository) : `index.html`, `styles.css`, `main.js`, `config.example.js` (à renommer), et le présent `README.md`.
-- Le script SQL de création de la base de données Supabase (non fourni ici) contenant les tables de mesures et les fonctions RPC suivantes : `kpis_peaks_range`, `peaks_in_range`, `summary_by_tag_range`, `readings_extent`. **Assurez-vous d’avoir ces procédures dans votre base** avec les bonnes définitions (selon votre modèle de données).
-
-## Installation et Configuration
-
-1. **Créer le projet Supabase** – Connectez-vous à Supabase et créez un nouveau projet. Notez l’URL du projet (format `https://xyzcompany.supabase.co`) et la **clé API anonyme** (dans Settings > API > Project API keys).
-2. **Importer le schéma SQL** – Dans l’onglet “SQL Editor” de votre projet Supabase, exécutez le script SQL d’importation qui crée les tables nécessaires (mesures, activités, etc.) et les fonctions RPC mentionnées ci-dessus. Assurez-vous que les noms de fonctions et de colonnes correspondent bien à ceux utilisés dans le code front-end.
-3. **Configurer le front-end** – Renommez le fichier `config.example.js` en `config.js`. Ouvrez-le et renseignez vos identifiants Supabase :
-   ```js
-   window.SUPABASE_URL = "https://<ID_PROJET>.supabase.co";
-   window.SUPABASE_ANON_KEY = "<CLE_API_ANONYME>";
+Ce projet mesure la qualité de l’air dans un atelier.

--- a/docs/404.html
+++ b/docs/404.html
@@ -12,14 +12,14 @@
       theme: {
         extend: {
           colors: {
-            primary:'#E11D48',
-            'primary-hover':'#BE123C',
-            text:'#0F172A',
-            secondary:'#475569',
-            border:'#E5E7EB',
-            success:'#10B981',
-            warning:'#F59E0B',
-            danger:'#EF4444'
+            primary:'#6A656F',
+            'primary-hover':'#5D5863',
+            text:'#0E1F23',
+            secondary:'#5C5962',
+            border:'#D2CFDA',
+            success:'#3F7666',
+            warning:'#9A7B4F',
+            danger:'#8C4A5A'
           },
           borderRadius: { 'xl2': '1rem', 'xl3': '1.25rem' }
         }
@@ -113,7 +113,7 @@
       <div class="card overflow-x-auto">
         <h3 class="section-title mb-3">Activités → Risque</h3>
         <table class="min-w-full table-zebra text-sm">
-          <thead class="sticky top-0 bg-white">
+          <thead class="sticky top-0 bg-[#F7F5FB]">
             <tr class="text-left text-secondary">
               <th class="py-2 pr-4">Hashtag</th>
               <th class="py-2 px-4 text-right">Heures</th>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,14 +19,14 @@
       theme: {
         extend: {
           colors: {
-            primary:'#E11D48',
-            'primary-hover':'#BE123C',
-            text:'#0F172A',
-            secondary:'#475569',
-            border:'#E5E7EB',
-            success:'#10B981',
-            warning:'#F59E0B',
-            danger:'#EF4444'
+            primary:'#6A656F',
+            'primary-hover':'#5D5863',
+            text:'#0E1F23',
+            secondary:'#5C5962',
+            border:'#D2CFDA',
+            success:'#3F7666',
+            warning:'#9A7B4F',
+            danger:'#8C4A5A'
           },
           borderRadius: { 'xl2': '1rem', 'xl3': '1.25rem' }
         }

--- a/docs/main.js
+++ b/docs/main.js
@@ -1,11 +1,11 @@
 /* globals supabase, dayjs, Plotly, window, document */
 
 const COLORS = {
-  pm25: '#E11D48', // rouge principal
-  pm10: '#2563EB', // bleu
-  pm1:  '#7C3AED', // violet pour distinguer visuellement la 3e trace
-  grid: '#E5E7EB',
-  text: '#0F172A'
+  pm25: '#0E1F23', // accent profond pour le PM2.5
+  pm10: '#757179', // gris chaud pour le PM10
+  pm1:  '#B6B0D5', // lavande claire pour distinguer le PM1
+  grid: '#D2CFDA',
+  text: '#0E1F23'
 };
 
 const WHO_LINE = 15; // µg/m³
@@ -145,7 +145,7 @@ function plotOne(containerId, serie, title, xRange) {
     legend:{ orientation:'h', x:0, xanchor:'left', y:1.2 },
     shapes: [
       { type:'line', xref:'paper', x0:0, x1:1, y0:WHO_LINE, y1:WHO_LINE,
-        line:{ dash:'dash', width:1, color:'#475569' } },
+        line:{ dash:'dash', width:1, color:'#5C5962' } },
       { type:'rect', xref:'paper', x0:0, x1:1, y0:WHO_LINE, y1:ymax,
         fillcolor:COLORS.pm25, opacity:0.06, line:{ width:0 } }
     ]

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,18 +1,20 @@
 /* Design tokens */
+/* Palette extraite de l'image de référence :
+   #E6E5E7, #B6B0D5, #E8E3F1, #757179, #0E1F23 */
 :root {
-  --primary: #E11D48;
-  --primary-hover: #BE123C;
-  --text: #0F172A;
-  --secondary: #475569;
-  --caption: #94A3B8;
-  --background: #F8FAFC;
-  --surface-soft: #F1F5F9;
-  --panel: #FFFFFF;
-  --border: #E5E7EB;
-  --success: #047857;
-  --warning: #B45309;
-  --danger: #B91C1C;
-  --shadow-soft: 0 24px 48px -32px rgba(15, 23, 42, 0.45);
+  --primary: #6A656F;
+  --primary-hover: #5D5863;
+  --text: #0E1F23;
+  --secondary: #5C5962;
+  --caption: #8E8A97;
+  --background: #E6E5E7;
+  --surface-soft: #E8E3F1;
+  --panel: #F7F5FB;
+  --border: #D2CFDA;
+  --success: #3F7666;
+  --warning: #9A7B4F;
+  --danger: #8C4A5A;
+  --shadow-soft: 0 24px 48px -32px rgba(14, 31, 35, 0.45);
 }
 
 body {
@@ -237,14 +239,14 @@ h3 {
 }
 
 .tw-btn:focus-visible {
-  outline: 2px solid rgba(225, 29, 72, 0.32);
+  outline: 2px solid rgba(106, 101, 111, 0.32);
   outline-offset: 2px;
-  box-shadow: 0 0 0 2px rgba(225, 29, 72, 0.18);
+  box-shadow: 0 0 0 2px rgba(106, 101, 111, 0.18);
 }
 
 .tw-btn-primary {
   background: var(--primary);
-  color: #FFFFFF;
+  color: #F7F5FB;
 }
 
 .tw-btn-primary:hover {
@@ -252,7 +254,7 @@ h3 {
 }
 
 .tw-btn-primary:active {
-  background: #9F1239;
+  background: #4F4B55;
 }
 
 .tw-btn-outline {
@@ -262,11 +264,11 @@ h3 {
 }
 
 .tw-btn-outline:hover {
-  background: rgba(225, 29, 72, 0.08);
+  background: rgba(106, 101, 111, 0.12);
 }
 
 .tw-btn-outline:active {
-  background: rgba(225, 29, 72, 0.12);
+  background: rgba(106, 101, 111, 0.18);
 }
 
 .tw-btn-ghost {
@@ -275,13 +277,13 @@ h3 {
 }
 
 .tw-btn-ghost:hover {
-  background: rgba(15, 23, 42, 0.04);
+  background: rgba(14, 31, 35, 0.06);
 }
 
 .tw-input {
   height: 44px;
   border: 1px solid var(--border);
-  background: #FFFFFF;
+  background: var(--panel);
   padding: 0 16px;
   border-radius: 12px;
   font-size: 0.9375rem;
@@ -292,9 +294,9 @@ h3 {
 
 .tw-input:focus-visible {
   border-color: var(--primary);
-  outline: 2px solid rgba(225, 29, 72, 0.26);
+  outline: 2px solid rgba(106, 101, 111, 0.26);
   outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(225, 29, 72, 0.12);
+  box-shadow: 0 0 0 4px rgba(106, 101, 111, 0.16);
 }
 
 .tw-input::-webkit-calendar-picker-indicator {
@@ -316,21 +318,21 @@ h3 {
 }
 
 .status-pill--ok {
-  color: #047857;
-  background: rgba(4, 120, 87, 0.16);
-  border-color: rgba(4, 120, 87, 0.32);
+  color: var(--secondary);
+  background: rgba(182, 176, 213, 0.24);
+  border-color: rgba(182, 176, 213, 0.5);
 }
 
 .status-pill--warn {
-  color: #B45309;
-  background: rgba(217, 119, 6, 0.18);
-  border-color: rgba(217, 119, 6, 0.36);
+  color: var(--secondary);
+  background: rgba(106, 101, 111, 0.18);
+  border-color: rgba(106, 101, 111, 0.36);
 }
 
 .status-pill--risk {
-  color: #B91C1C;
-  background: rgba(220, 38, 38, 0.18);
-  border-color: rgba(220, 38, 38, 0.36);
+  color: var(--text);
+  background: rgba(14, 31, 35, 0.12);
+  border-color: rgba(14, 31, 35, 0.3);
 }
 
 .table-scroll {
@@ -378,7 +380,7 @@ h3 {
 }
 
 .data-table tbody tr:hover td {
-  background: rgba(15, 23, 42, 0.02);
+  background: rgba(14, 31, 35, 0.04);
 }
 
 .stacked-list {


### PR DESCRIPTION
## Summary
- trim the README down to the short atelier air-quality introduction
- rework design tokens, components, and focus states to match the supplied neutral–lavender palette
- update chart traces and Tailwind CDN configs (including the 404 fallback) so every surface follows the new colors

## Testing
- not run (static assets)

------
https://chatgpt.com/codex/tasks/task_e_68c861e842288332ab8cfef873c1bc5e