### PR TITLE
Revamp header logotype

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,11 +40,20 @@
 
   <!-- Header -->
   <header class="layout-container py-6 flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
-    <div class="flex items-center gap-4">
-      <div class="h-12 w-12 rounded-2xl bg-primary grid place-items-center text-white text-lg font-semibold tracking-tight">
-        AQ
+    <div class="brand flex items-center gap-5">
+      <div class="brand-mark" aria-hidden="true">
+        <svg class="brand-icon" viewBox="0 0 64 64" role="img" focusable="false">
+          <path d="M18 46 L29 18 L40 46" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M23.5 33.5H33.5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+          <path d="M40.5 22c6.6 0 11.5 4.9 11.5 11.5S47.1 45 40.5 45c-4.9 0-8.7-2.6-10.9-6.5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M45.5 38.2l6.3 6.5" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" />
+          <path d="M35.2 26.2c3.5-3.1 9.4-3.3 12.9-0.3" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.75" />
+        </svg>
       </div>
-      <h1 class="text-balance">Qualité de l’air</h1>
+      <div class="brand-copy">
+        <h1 class="brand-title text-balance">Qualité de l’air</h1>
+        <p class="brand-subtitle">Atelier de données atmosphériques</p>
+      </div>
     </div>
 
   </header>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -40,6 +40,97 @@ h1 {
   font-weight: 600;
 }
 
+.brand {
+  position: relative;
+}
+
+.brand-mark {
+  width: 64px;
+  height: 64px;
+  border-radius: 22px;
+  background: linear-gradient(140deg, #B01B37 0%, #D6435B 52%, #F47B80 100%);
+  box-shadow: 0 28px 40px -26px rgba(176, 27, 55, 0.7);
+  display: grid;
+  place-items: center;
+  color: #FFF5F6;
+  position: relative;
+  overflow: hidden;
+}
+
+.brand-mark::after {
+  content: "";
+  position: absolute;
+  inset: 10px 12px 18px;
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.brand-icon {
+  width: 70%;
+  height: 70%;
+  z-index: 1;
+}
+
+.brand-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  line-height: 1.05;
+}
+
+.brand-title {
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(28px, 2.8vw, 32px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  font-weight: 600;
+  padding: 4px 12px 4px 0;
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.brand-subtitle::after {
+  content: "";
+  display: block;
+  flex-shrink: 0;
+  width: 42px;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(176, 27, 55, 0.65), rgba(176, 27, 55, 0));
+}
+
+@media (max-width: 640px) {
+  .brand-mark {
+    width: 56px;
+    height: 56px;
+    border-radius: 20px;
+  }
+
+  .brand-title {
+    font-size: clamp(24px, 7vw, 30px);
+  }
+
+  .brand-subtitle {
+    letter-spacing: 0.2em;
+    font-size: 0.6875rem;
+  }
+
+  .brand-subtitle::after {
+    width: 28px;
+  }
+}
+
 h2 {
   font-size: 20px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- replace the red "AQ" block with a bespoke monogram that combines the initials with an airy motif while keeping the header layout horizontal
- refine the heading stack with a dedicated brand title and subtitle styling to give the hero a more luxurious tone

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c86716b0308332acac49d0aafe3ca0