### PR TITLE
Update page title and subtitle copy

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Qualité de l’air — Atelier</title>
+  <title>Atelier Céramique – Niveau de particules</title>
   <link rel="icon" href="favicon.ico" type="image/ico" />
   <!-- Tailwind (CDN) -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -35,7 +35,7 @@
   <header class="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
     <div class="flex items-center gap-3">
       <div class="h-9 w-9 rounded-2xl bg-primary/90 grid place-items-center text-white font-bold">AQ</div>
-      <h1 class="text-xl font-semibold text-text">Qualité de l’air</h1>
+      <h1 class="text-xl font-semibold text-text">Atelier Céramique</h1>
     </div>
 
     <div class="flex items-center gap-3">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Qualité de l’air — Atelier</title>
+  <title>Atelier Céramique – Niveau de particules</title>
   <link rel="icon" href="favicon-96X96.png" type="image/png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -51,8 +51,8 @@
         </svg>
       </div>
       <div class="brand-copy">
-        <h1 class="brand-title text-balance">Qualité de l’air</h1>
-        <p class="brand-subtitle">Atelier de données atmosphériques</p>
+        <h1 class="brand-title text-balance">Atelier Céramique</h1>
+        <p class="brand-subtitle">Niveau de particules</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- update the main dashboard title and subtitle text to the new "Atelier Céramique" branding
- align the document titles and 404 page header with the same copy change

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68c8746e74b483328fec92332a6573ee