### PR TITLE
Use emerald green for positive air quality indicators

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -17,7 +17,7 @@
             text:'#424341',
             secondary:'#545858',
             border:'#AAAFAF',
-            success:'#424341',
+            success:'#027148',
             warning:'#AAAFAF',
             danger:'#5E5862'
           },

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
             text:'#424341',
             secondary:'#545858',
             border:'#AAAFAF',
-            success:'#424341',
+            success:'#027148',
             warning:'#AAAFAF',
             danger:'#5E5862'
           },

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -11,7 +11,7 @@
   --surface-soft: #D7D1D1;
   --panel: #F1F3F3;
   --border: #AAAFAF;
-  --success: #424341;
+  --success: #027148;
   --warning: #AAAFAF;
   --danger: #5E5862;
   --shadow-soft: 0 24px 48px -32px rgba(66, 67, 65, 0.3);
@@ -262,11 +262,11 @@ h3 {
 }
 
 .kpi-trend-icon.is-up {
-  color: var(--success);
+  color: var(--danger);
 }
 
 .kpi-trend-icon.is-down {
-  color: var(--danger);
+  color: var(--success);
 }
 
 .kpi-trend-icon.is-flat {


### PR DESCRIPTION
## Summary
- update the success design token to the requested emerald hex value
- swap KPI arrow colors so downward trends use the positive emerald and upward trends use the danger tone
- align Tailwind inline configs with the new success color for both the main and fallback pages

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c9b6611da88332a57cb86abdb7986b