### PR TITLE
Stabilize KPI layout and animation

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -188,8 +188,14 @@ h3 {
 }
 
 .kpi-card {
-  min-height: 140px;
+  height: 192px;
   justify-content: space-between;
+}
+
+@media (min-width: 768px) {
+  .kpi-card {
+    height: 160px;
+  }
 }
 
 .kpi-header {
@@ -241,14 +247,27 @@ h3 {
   flex-direction: column;
   align-items: flex-end;
   justify-content: flex-start;
-  min-width: var(--roller-min-width, 3.5ch);
+  min-width: max(var(--roller-min-width, 3.5ch), var(--kpi-fixed-min-ch, 3.5ch));
   overflow: hidden;
   backface-visibility: hidden;
+}
+
+#kpi-peaks {
+  --kpi-fixed-min-ch: 5ch;
+}
+
+#kpi-last {
+  --kpi-fixed-min-ch: 4ch;
+}
+
+#kpi-pct {
+  --kpi-fixed-min-ch: 4.5ch;
 }
 
 .kpi-roller-track {
   display: flex;
   flex-direction: column;
+  contain: layout paint;
   will-change: transform, filter;
   transform: translateZ(0);
 }


### PR DESCRIPTION
## Summary
- reserve fixed KPI card dimensions and tabular-width slots to prevent layout shifts
- simplify the metric animator to remove placeholder rolls, guard against stalled animations, and render the chart after KPI updates
- slow the KPI roller duration range to roughly 300–500 ms so the transition remains perceptible while still honoring the jitter guard

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9d832898c8332b936fa703533a27b