### PR TITLE
Adjust metric roller animation duration

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -90,12 +90,16 @@ function createMetricAnimator() {
     ? window.matchMedia('(prefers-reduced-motion: reduce)')
     : null;
   let prefersReduced = !!(reduceQuery && reduceQuery.matches);
-  const MAX_PENDING_ANIMATION_MS = 120;
+  const DEFAULT_ROLL_DURATION_RANGE_MS = [300, 500];
+  const MAX_PENDING_ANIMATION_MS = 320;
 
   class MetricRoller {
     constructor(el, opts = {}) {
       this.el = el;
-      this.durationRange = opts.durationRange || [350, 600];
+      const customRange = Array.isArray(opts.durationRange)
+        ? opts.durationRange.slice(0, 2)
+        : null;
+      this.durationRange = customRange || DEFAULT_ROLL_DURATION_RANGE_MS;
       this.baseDigits = opts.baseDigits ?? 3;
       this.prefersReduced = prefersReduced;
       this.isAnimating = false;


### PR DESCRIPTION
## Summary
- slow the KPI roller animation to a 300–500 ms range
- extend the pending animation allowance to keep longer transitions smooth
- preserve optional custom durations by safely copying provided ranges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9e4da7e3c8332be10249de4264d6a