### PR TITLE
Add Google Calendar browser key

### DIFF
--- a/docs/config.js
+++ b/docs/config.js
@@ -4,4 +4,4 @@ window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXB
 window.GCAL_CALENDAR_ID = "sji17cho35m52lhecchvsfqn08@group.calendar.google.com";
 window.GCAL_PUBLIC_ICAL_URL = "https://calendar.google.com/calendar/ical/sji17cho35m52lhecchvsfqn08%40group.calendar.google.com/public/basic.ics";
 window.GCAL_PUBLIC_EMBED_URL = "https://calendar.google.com/calendar/embed?src=sji17cho35m52lhecchvsfqn08%40group.calendar.google.com&ctz=Europe%2FParis";
-window.GCAL_BROWSER_KEY = window.GCAL_BROWSER_KEY || "";
+window.GCAL_BROWSER_KEY = window.GCAL_BROWSER_KEY || "AIzaSyCXGUZKhvSGcs2xBpDbCx9XA9kxiofB6QY";


### PR DESCRIPTION
## Summary
- populate the Google Calendar browser API key in docs/config.js so the activity risk widget can query events

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca64ddbfe48332b2ad932a7f19865e