### PR TITLE
Refactor activity risk cell to display calendar events with PM2.5 metrics

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -626,6 +626,16 @@ h3 {
   min-width: 0;
 }
 
+.activity-risk-title {
+  flex: 1 1 180px;
+  font-weight: 600;
+  color: var(--text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .activity-risk-type {
   display: inline-flex;
   align-items: center;
@@ -717,6 +727,17 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.activity-risk-row .activity-risk-sparkline {
+  min-width: 72px;
+}
+
+.activity-risk-snapshot {
+  font-size: 0.85rem;
+  color: var(--secondary);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .activity-risk-sparkline svg {


### PR DESCRIPTION
## Summary
- replace the Activités → Risque widget logic to fetch confirmed Google Calendar events in the selected window and classify them into running and finished activities
- slice the cached PM2.5 series for each event to render sparklines and PM2.5 statistics, including warning and alert percentages
- style the event list to show the type badge, schedule, title, sparkline, and numerical snapshot inline

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ca9558088c8332bed0038038501667