### PR TITLE
Filter out example.csv rows from risk table

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -743,8 +743,12 @@ async function reloadDashboard() {
   const sum = await summaryByTag(summaryStartISO, summaryEndISO);
   const tbody = document.getElementById('tbl-acts');
   tbody.innerHTML = '';
-  sum.sort((a,b)=>( (b.peaks/(b.duration||1)) - (a.peaks/(a.duration||1)) ));
-  sum.forEach(r=>{
+  const filtered = sum.filter((row) => {
+    const tag = typeof row.tag === 'string' ? row.tag.toLowerCase() : '';
+    return tag && !tag.includes('example.csv');
+  });
+  filtered.sort((a,b)=>( (b.peaks/(b.duration||1)) - (a.peaks/(a.duration||1)) ));
+  filtered.forEach(r=>{
     const tr = document.createElement('tr');
     tr.innerHTML = `
       <td>${r.tag}</td>


### PR DESCRIPTION
## Summary
- filter the Activities → Risk table data to drop rows coming from example.csv sources so only calendar content remains

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca9d648fb08332a425bd410545b249