### PR TITLE
Color-code PM₂.₅ KPI values and status visuals

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,7 @@
       <div class="card kpi-card md:col-span-4">
         <div class="kpi-header">
           <p class="kpi-label">Temps au-dessus du seuil</p>
-          <span class="kpi-icon" aria-hidden="true">
+          <span id="kpi-pct-icon" class="kpi-icon" aria-hidden="true">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M5 19H19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
               <path d="M7 16L11.5 7.5L14.5 13L17 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -223,6 +223,21 @@ h3 {
   color: var(--secondary);
 }
 
+.kpi-icon[data-state="ok"] {
+  background: rgba(63, 118, 102, 0.16);
+  color: var(--success);
+}
+
+.kpi-icon[data-state="warn"] {
+  background: rgba(209, 141, 30, 0.16);
+  color: var(--warning);
+}
+
+.kpi-icon[data-state="risk"] {
+  background: rgba(176, 91, 91, 0.16);
+  color: var(--danger);
+}
+
 .kpi-metric {
   display: flex;
   align-items: flex-end;
@@ -250,6 +265,21 @@ h3 {
   min-width: max(var(--roller-min-width, 3.5ch), var(--kpi-fixed-min-ch, 3.5ch));
   overflow: hidden;
   backface-visibility: hidden;
+}
+
+.kpi-value[data-severity="good"],
+#kpi-last[data-severity="good"] {
+  color: var(--success);
+}
+
+.kpi-value[data-severity="warn"],
+#kpi-last[data-severity="warn"] {
+  color: var(--warning);
+}
+
+.kpi-value[data-severity="risk"],
+#kpi-last[data-severity="risk"] {
+  color: var(--danger);
 }
 
 #kpi-peaks {
@@ -446,6 +476,7 @@ h3 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
   padding: 8px 16px;
   border-radius: 12px;
   font-size: 0.75rem;
@@ -456,10 +487,20 @@ h3 {
   border: 1px solid var(--border);
 }
 
+.status-pill::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  display: block;
+  flex-shrink: 0;
+  background: currentColor;
+}
+
 .status-pill--ok {
-  color: var(--primary);
-  background: rgba(55, 79, 78, 0.12);
-  border-color: rgba(55, 79, 78, 0.28);
+  color: var(--success);
+  background: rgba(63, 118, 102, 0.12);
+  border-color: rgba(63, 118, 102, 0.28);
 }
 
 .status-pill--warn {
@@ -469,9 +510,9 @@ h3 {
 }
 
 .status-pill--risk {
-  color: var(--secondary);
-  background: rgba(170, 133, 82, 0.14);
-  border-color: rgba(170, 133, 82, 0.32);
+  color: var(--danger);
+  background: rgba(176, 91, 91, 0.16);
+  border-color: rgba(176, 91, 91, 0.32);
 }
 
 .table-scroll {


### PR DESCRIPTION
## Summary
- add severity helpers to flag PM₂.₅ readings and reuse them to color the current value display
- synchronize the status pill and icon colors so OK/A surveiller/À risque states are visually explicit
- refresh KPI styling to show small status dots and tint icons based on the current state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caab0e33dc8332b342b5419ff17907