### PR TITLE
Retirer complètement l'effet de barillet sur les KPI principaux

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -262,7 +262,7 @@ h3 {
   flex-direction: column;
   align-items: flex-end;
   justify-content: flex-start;
-  min-width: max(var(--roller-min-width, 3.5ch), var(--kpi-fixed-min-ch, 3.5ch));
+  min-width: var(--kpi-fixed-min-ch, 3.5ch);
   overflow: hidden;
   backface-visibility: hidden;
 }
@@ -292,28 +292,6 @@ h3 {
 
 #kpi-pct {
   --kpi-fixed-min-ch: 4.5ch;
-}
-
-.kpi-roller-track {
-  display: flex;
-  flex-direction: column;
-  contain: layout paint;
-  will-change: transform, filter;
-  transform: translateZ(0);
-}
-
-.kpi-roller-slot {
-  display: block;
-  text-align: right;
-  line-height: 1;
-}
-
-.kpi-roller-slot.is-rolling-out {
-  opacity: 0.35;
-}
-
-.kpi-roller-slot.is-rolling-in {
-  opacity: 1;
 }
 
 .kpi-unit {


### PR DESCRIPTION
## Summary
- simplifie `createMetricAnimator` pour ne plus créer la mécanique de barillet et mettre à jour directement le texte des KPI
- nettoie l'initialisation des KPI et supprime les styles CSS dédiés aux pistes de roulage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cac347361c8332958baf4f515a1bc7