### PR TITLE
Remove legacy calendar hooks and simplify activity loading

### DIFF
--- a/docs/config.example.js
+++ b/docs/config.example.js
@@ -1,12 +1,8 @@
 // Configuration for Air Quality Dashboard
 // Copy this file to config.js and update with your Supabase credentials
 
-const SUPABASE_URL = 'https://your-project-ref.supabase.co';
-const SUPABASE_ANON_KEY = 'your-anon-public-key-here';
-const GCAL_BROWSER_KEY = 'your-google-calendar-browser-key';
-const GCAL_CALENDAR_ID = 'your-calendar-id@group.calendar.google.com';
-const GCAL_PUBLIC_ICAL_URL = 'https://calendar.google.com/calendar/ical/your-calendar-id%40group.calendar.google.com/public/basic.ics';
-const GCAL_PUBLIC_EMBED_URL = 'https://calendar.google.com/calendar/embed?src=your-calendar-id%40group.calendar.google.com&ctz=Europe%2FParis';
+window.SUPABASE_URL = 'https://your-project-ref.supabase.co';
+window.SUPABASE_ANON_KEY = 'your-anon-public-key-here';
 
 // Optional: Custom configuration
 const CONFIG = {

--- a/docs/config.js
+++ b/docs/config.js
@@ -1,7 +1,3 @@
 // Config example for Supabase connection (rename to config.js and insert your credentials)
 window.SUPABASE_URL = "https://lzszrnaciqywpbdchgso.supabase.co";
 window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imx6c3pybmFjaXF5d3BiZGNoZ3NvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU4NzUyMDIsImV4cCI6MjA3MTQ1MTIwMn0.0AczSYj_8aAgVHh--jc0olbh3LVRMorO1MFilVR4dPY";
-window.GCAL_CALENDAR_ID = "sji17cho35m52lhecchvsfqn08@group.calendar.google.com";
-window.GCAL_PUBLIC_ICAL_URL = "https://calendar.google.com/calendar/ical/sji17cho35m52lhecchvsfqn08%40group.calendar.google.com/public/basic.ics";
-window.GCAL_PUBLIC_EMBED_URL = "https://calendar.google.com/calendar/embed?src=sji17cho35m52lhecchvsfqn08%40group.calendar.google.com&ctz=Europe%2FParis";
-window.GCAL_BROWSER_KEY = window.GCAL_BROWSER_KEY || "AIzaSyCXGUZKhvSGcs2xBpDbCx9XA9kxiofB6QY";


### PR DESCRIPTION
## Summary
- drop the unused Google Calendar configuration values from the example and default config
- load activities through the Supabase client without manual fetch timeouts
- remove Promise.all usage and other legacy timeouts while keeping dataset loading intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caeccfc6e083328c6b14e6a71c51e3