### PR TITLE
Fix Supabase activities RPC invocation

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -386,7 +386,7 @@ function getCachedActivities(range) {
 }
 
 async function fetchActivities(range) {
-  const { data, error } = await sb.rpc('app.activities_site', { range });
+  const { data, error } = await sb.rpc('activities_site', { p_range: range });
   if (error) throw error;
   return Array.isArray(data) ? data : [];
 }


### PR DESCRIPTION
## Summary
- call the Supabase activities_site RPC without schema qualification
- pass the range argument using the expected p_range parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caf308cd088332add615ec91deec87