### PR TITLE
Make activities list scrollable with range anchors

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -567,6 +567,14 @@ h3 {
   letter-spacing: 0.08em;
 }
 
+.activities-scroller {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: hidden;
+  scrollbar-gutter: stable both-edges;
+}
+
 .activities-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- wrap the activities → risque list in a scrollable container that only grows to twenty rows before enabling scrolling
- compute the scroll height dynamically so long lists stay usable while shorter lists keep their natural height
- jump the scroller to the start of the current range (top for 7 jours, eighth day for 30 jours) when the range buttons are used

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc5b6f32c883328c5b34d7a2fa85ba