### PR TITLE
Limit activity scroller to 10 events

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -465,7 +465,7 @@ function enforceActivitiesScrollLimit(scroller, list) {
       return;
     }
 
-    const maxVisible = 20;
+    const maxVisible = 10;
     const sampleCount = Math.min(rows.length, maxVisible);
 
     let totalHeight = 0;


### PR DESCRIPTION
## Summary
- restrict the activity list scroller to a maximum height based on 10 rows instead of 20

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc5de88ca483328880b7016c77eaa4