### PR TITLE
Add activity sorting controls and simplify activity rows

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -619,16 +619,41 @@ h3 {
   box-shadow: 0 0 0 2px rgba(255, 59, 48, 0.18);
 }
 
-.activity-badge {
-  flex-shrink: 0;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: rgba(55, 79, 78, 0.16);
-  color: var(--primary);
-  font-size: 0.75rem;
+.activities-controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.activities-sort-label {
+  font-size: 0.875rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: var(--secondary);
+}
+
+.activities-sort-select {
+  min-width: 160px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(55, 79, 78, 0.24);
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.activities-sort-select:hover {
+  border-color: rgba(55, 79, 78, 0.4);
+}
+
+.activities-sort-select:focus-visible {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(55, 79, 78, 0.25);
 }
 
 .activity-time {
@@ -648,10 +673,6 @@ h3 {
   gap: 6px;
 }
 
-.activity-person {
-  font-weight: 500;
-  color: var(--secondary);
-}
 
 .activity-sparkline {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- add client-side sorting controls to the activity list with default status and alphabetical options
- persist the selected sort while re-rendering and keep cached data for resorting without new requests
- remove duplicate labels and person names from activity rows and refresh related styles

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc6e427ed88332a96aaac973edc2db