### PR TITLE
Fix filter panel collapse animation

### DIFF
--- a/docs/main.js
+++ b/docs/main.js
@@ -707,7 +707,7 @@ function buildActivitiesControls(options = []) {
       return;
     }
     if (isOpen) {
-      panel.style.maxHeight = '';
+      panel.style.maxHeight = 'none';
     } else {
       panel.hidden = true;
       panel.style.maxHeight = '0px';


### PR DESCRIPTION
## Summary
- prevent the activities filter panel from collapsing after the expand transition completes by keeping its max-height unlimited

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cc8b0f60608332b02010e516f6e6f2