### PR TITLE
Apply red-first palette across UI and charts

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -12,14 +12,19 @@
       theme: {
         extend: {
           colors: {
-            primary:'#424341',
-            'primary-hover':'#2F3030',
-            text:'#424341',
-            secondary:'#545858',
-            border:'#AAAFAF',
-            success:'#027148',
-            warning:'#AAAFAF',
-            danger:'#5E5862'
+            primary:'#DF2935',
+            'primary-hover':'#C1202B',
+            'primary-active':'#A31B24',
+            text:'#080708',
+            secondary:'#811EEB',
+            caption:'#6C54A6',
+            border:'#F5C9CE',
+            background:'#FFF7F6',
+            surface:'#FFE7E4',
+            panel:'#FFFFFF',
+            success:'#1E9E6A',
+            warning:'#FDCA40',
+            danger:'#DF2935'
           },
           borderRadius: { 'xl2': '1rem', 'xl3': '1.25rem' }
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,14 +19,19 @@
       theme: {
         extend: {
           colors: {
-            primary:'#424341',
-            'primary-hover':'#2F3030',
-            text:'#424341',
-            secondary:'#545858',
-            border:'#AAAFAF',
-            success:'#027148',
-            warning:'#AAAFAF',
-            danger:'#5E5862'
+            primary:'#DF2935',
+            'primary-hover':'#C1202B',
+            'primary-active':'#A31B24',
+            text:'#080708',
+            secondary:'#811EEB',
+            caption:'#6C54A6',
+            border:'#F5C9CE',
+            background:'#FFF7F6',
+            surface:'#FFE7E4',
+            panel:'#FFFFFF',
+            success:'#1E9E6A',
+            warning:'#FDCA40',
+            danger:'#DF2935'
           },
           borderRadius: { 'xl2': '1rem', 'xl3': '1.25rem' }
         }

--- a/docs/main.js
+++ b/docs/main.js
@@ -3,12 +3,12 @@
 function getThemeColors() {
   if (typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') {
     return {
-      pm25: '#424341',
-      pm10: '#AFA9B4',
-      pm1: '#AAAFAF',
-      grid: '#C3C8C8',
-      text: '#424341',
-      panel: '#FBF4EA'
+      pm25: '#FDCA40',
+      pm10: '#811EEB',
+      pm1: '#0047AB',
+      grid: '#F5C9CE',
+      text: '#080708',
+      panel: '#FFFFFF'
     };
   }
 
@@ -19,12 +19,12 @@ function getThemeColors() {
   };
 
   return {
-    pm25: read('--primary', '#424341'),
-    pm10: read('--secondary', '#AFA9B4'),
-    pm1: read('--warning', '#AAAFAF'),
-    grid: read('--border', '#C3C8C8'),
-    text: read('--text', '#424341'),
-    panel: read('--panel', '#FBF4EA')
+    pm25: read('--chart-pm25', read('--warning', '#FDCA40')),
+    pm10: read('--chart-pm10', read('--secondary', '#811EEB')),
+    pm1: read('--chart-pm1', '#0047AB'),
+    grid: read('--border', '#F5C9CE'),
+    text: read('--text', '#080708'),
+    panel: read('--panel', '#FFFFFF')
   };
 }
 
@@ -48,8 +48,8 @@ const WHO_LINE = 15; // µg/m³
 
 const sb = supabase.createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
 
-const HIGHLIGHT_FILL = 'rgba(255, 59, 48, 0.18)';
-const HIGHLIGHT_BORDER = 'rgba(255, 59, 48, 0.8)';
+const HIGHLIGHT_FILL = 'rgba(223, 41, 53, 0.16)';
+const HIGHLIGHT_BORDER = 'rgba(223, 41, 53, 0.8)';
 const ACTIVITIES_CACHE_TTL = 60 * 1000;
 const activitiesCache = Object.create(null);
 let highlightDetail = null;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,25 +1,29 @@
 /* Design tokens */
-/* Palette extraite de l'image de référence :
-   #0047AB, #080708, #DF2935, #FDC4A0, #811EEB */
+/* Palette principale :
+   Rouge DF2935, Violet 811EEB, Jaune FDCA40, Bleu 0047AB, Noir 080708 */
 :root {
-  --primary: #0047AB;
-  --primary-hover: #003B8F;
+  --primary: #DF2935;
+  --primary-hover: #C1202B;
+  --primary-active: #A31B24;
   --text: #080708;
   --secondary: #811EEB;
-  --caption: #575B6D;
-  --background: #F6F8FF;
-  --surface-soft: #E8EEFF;
+  --caption: #6C54A6;
+  --background: #FFF7F6;
+  --surface-soft: #FFE7E4;
   --panel: #FFFFFF;
-  --border: #D5DDF5;
+  --border: #F5C9CE;
   --success: #1E9E6A;
-  --warning: #F28F3B;
+  --warning: #FDCA40;
   --danger: #DF2935;
-  --primary-rgb: 0, 71, 171;
+  --primary-rgb: 223, 41, 53;
   --secondary-rgb: 129, 30, 235;
   --success-rgb: 30, 158, 106;
-  --warning-rgb: 242, 143, 59;
+  --warning-rgb: 253, 202, 64;
   --danger-rgb: 223, 41, 53;
-  --shadow-soft: 0 24px 48px -32px rgba(var(--primary-rgb), 0.28);
+  --chart-pm25: #FDCA40;
+  --chart-pm10: #811EEB;
+  --chart-pm1: #0047AB;
+  --shadow-soft: 0 24px 48px -32px rgba(var(--primary-rgb), 0.22);
 }
 
 body {
@@ -53,11 +57,11 @@ h1 {
   width: 64px;
   height: 64px;
   border-radius: 22px;
-  background: linear-gradient(140deg, #0047AB 0%, #811EEB 56%, #FDC4A0 100%);
-  box-shadow: 0 28px 40px -26px rgba(var(--primary-rgb), 0.35);
+  background: linear-gradient(140deg, #DF2935 0%, #811EEB 56%, #FDCA40 100%);
+  box-shadow: 0 28px 40px -26px rgba(var(--primary-rgb), 0.32);
   display: grid;
   place-items: center;
-  color: #F5F7FF;
+  color: #FFF9F8;
   position: relative;
   overflow: hidden;
 }
@@ -383,7 +387,7 @@ h3 {
 
 .tw-btn-primary {
   background: var(--primary);
-  color: #F5F7FF;
+  color: #FFF9F8;
 }
 
 .tw-btn-primary:hover {
@@ -391,7 +395,7 @@ h3 {
 }
 
 .tw-btn-primary:active {
-  background: #002F6C;
+  background: var(--primary-active);
 }
 
 .tw-btn-outline {
@@ -673,7 +677,7 @@ h3 {
 
 .activities-controls.is-open .activities-filter-toggle {
   background: var(--primary);
-  color: #F5F7FF;
+  color: #FFF9F8;
   border-color: var(--primary-hover);
   box-shadow: 0 20px 42px -32px rgba(var(--primary-rgb), 0.5);
 }


### PR DESCRIPTION
## Summary
- restyle the global CSS design tokens around the red primary palette with light backgrounds and dedicated chart colors
- align the Tailwind CDN configuration with the new brand shades across both main and fallback pages
- update Plotly theme helpers so PM2.5 renders in yellow and highlights use the refreshed red accents

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cea0b17f148332b849a7941580db69