### PR TITLE
feat: refresh color palette

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -13,16 +13,16 @@
         extend: {
           colors: {
             primary:'#DF2935',
-            'primary-hover':'#C1202B',
-            'primary-active':'#A31B24',
+            'primary-hover':'#C2202C',
+            'primary-active':'#A61A23',
             text:'#080708',
             secondary:'#811EEB',
-            caption:'#6C54A6',
-            border:'#F5C9CE',
-            background:'#FFF7F6',
-            surface:'#FFE7E4',
+            caption:'#4C2BB7',
+            border:'#D9E0EE',
+            background:'#F5F7FA',
+            surface:'#EEF1F8',
             panel:'#FFFFFF',
-            success:'#1E9E6A',
+            success:'#138A5B',
             warning:'#FDCA40',
             danger:'#DF2935'
           },

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,16 +20,16 @@
         extend: {
           colors: {
             primary:'#DF2935',
-            'primary-hover':'#C1202B',
-            'primary-active':'#A31B24',
+            'primary-hover':'#C2202C',
+            'primary-active':'#A61A23',
             text:'#080708',
             secondary:'#811EEB',
-            caption:'#6C54A6',
-            border:'#F5C9CE',
-            background:'#FFF7F6',
-            surface:'#FFE7E4',
+            caption:'#4C2BB7',
+            border:'#D9E0EE',
+            background:'#F5F7FA',
+            surface:'#EEF1F8',
             panel:'#FFFFFF',
-            success:'#1E9E6A',
+            success:'#138A5B',
             warning:'#FDCA40',
             danger:'#DF2935'
           },

--- a/docs/main.js
+++ b/docs/main.js
@@ -6,7 +6,7 @@ function getThemeColors() {
       pm25: '#FDCA40',
       pm10: '#811EEB',
       pm1: '#0047AB',
-      grid: '#F5C9CE',
+      grid: '#D9E0EE',
       text: '#080708',
       panel: '#FFFFFF'
     };
@@ -22,7 +22,7 @@ function getThemeColors() {
     pm25: read('--chart-pm25', read('--warning', '#FDCA40')),
     pm10: read('--chart-pm10', read('--secondary', '#811EEB')),
     pm1: read('--chart-pm1', '#0047AB'),
-    grid: read('--border', '#F5C9CE'),
+    grid: read('--border', '#D9E0EE'),
     text: read('--text', '#080708'),
     panel: read('--panel', '#FFFFFF')
   };

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3,27 +3,27 @@
    Rouge DF2935, Violet 811EEB, Jaune FDCA40, Bleu 0047AB, Noir 080708 */
 :root {
   --primary: #DF2935;
-  --primary-hover: #C1202B;
-  --primary-active: #A31B24;
+  --primary-hover: #C2202C;
+  --primary-active: #A61A23;
   --text: #080708;
   --secondary: #811EEB;
-  --caption: #6C54A6;
-  --background: #FFF7F6;
-  --surface-soft: #FFE7E4;
+  --caption: #4C2BB7;
+  --background: #F5F7FA;
+  --surface-soft: #EEF1F8;
   --panel: #FFFFFF;
-  --border: #F5C9CE;
-  --success: #1E9E6A;
+  --border: #D9E0EE;
+  --success: #138A5B;
   --warning: #FDCA40;
   --danger: #DF2935;
   --primary-rgb: 223, 41, 53;
   --secondary-rgb: 129, 30, 235;
-  --success-rgb: 30, 158, 106;
+  --success-rgb: 19, 138, 91;
   --warning-rgb: 253, 202, 64;
   --danger-rgb: 223, 41, 53;
   --chart-pm25: #FDCA40;
   --chart-pm10: #811EEB;
   --chart-pm1: #0047AB;
-  --shadow-soft: 0 24px 48px -32px rgba(var(--primary-rgb), 0.22);
+  --shadow-soft: 0 24px 48px -32px rgba(8, 7, 8, 0.18);
 }
 
 body {
@@ -57,8 +57,8 @@ h1 {
   width: 64px;
   height: 64px;
   border-radius: 22px;
-  background: linear-gradient(140deg, #DF2935 0%, #811EEB 56%, #FDCA40 100%);
-  box-shadow: 0 28px 40px -26px rgba(var(--primary-rgb), 0.32);
+  background: var(--primary);
+  box-shadow: 0 28px 40px -28px rgba(8, 7, 8, 0.32);
   display: grid;
   place-items: center;
   color: #FFF9F8;
@@ -71,8 +71,8 @@ h1 {
   position: absolute;
   inset: 10px 12px 18px;
   border-radius: 18px;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
-  opacity: 0.7;
+  background: rgba(255, 255, 255, 0.12);
+  opacity: 1;
   pointer-events: none;
 }
 
@@ -116,11 +116,7 @@ h1 {
   flex-shrink: 0;
   width: 42px;
   height: 1px;
-  background: linear-gradient(
-    90deg,
-    rgba(var(--primary-rgb), 0.65),
-    rgba(var(--primary-rgb), 0)
-  );
+  background: rgba(var(--primary-rgb), 0.65);
 }
 
 @media (max-width: 640px) {
@@ -722,9 +718,9 @@ h3 {
   transform: translateY(0);
   pointer-events: auto;
   padding: 16px 18px;
-  border-color: rgba(var(--primary-rgb), 0.18);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 28px 54px -36px rgba(var(--primary-rgb), 0.45);
+  border-color: rgba(8, 7, 8, 0.08);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 28px 54px -36px rgba(8, 7, 8, 0.28);
 }
 
 .activities-filter-fields {
@@ -747,20 +743,20 @@ h3 {
   min-width: 200px;
   padding: 10px 16px;
   border-radius: 999px;
-  border: 1px solid rgba(var(--primary-rgb), 0.22);
-  background: rgba(232, 238, 255, 0.96);
+  border: 1px solid var(--border);
+  background: #FFFFFF;
   color: var(--text);
   font: inherit;
   font-weight: 600;
   font-size: 0.9375rem;
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.28s ease, background-color 0.28s ease;
-  box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.45);
+  box-shadow: inset 0 1px 2px rgba(8, 7, 8, 0.04);
 }
 
 .activities-sort-select:hover {
   border-color: rgba(var(--primary-rgb), 0.4);
-  background: rgba(232, 238, 255, 1);
+  background: #F5F7FA;
 }
 
 .activities-sort-select:focus-visible {


### PR DESCRIPTION
## Summary
- align global design tokens with the requested DF2935 / 811EEB / FDCA40 / 0047AB palette and lighten backgrounds without gradients
- update Tailwind CDN config and UI elements so hover, filter controls, and panels reuse the refreshed colors
- sync Plotly defaults with the new neutral grid color while keeping PM2.5 highlighted in yellow

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68cea3c299008332a31de6b33a0ec8e9