### PR TITLE
Remove PM1 display and improve KPI readability

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -62,7 +62,7 @@
         <div id="kpi-peaks" class="text-3xl font-semibold tabular-nums text-text">–</div>
       </div>
       <div class="card">
-        <div class="text-sm text-secondary mb-1">PM₂.₅ actuel</div>
+        <div class="text-sm text-secondary mb-1">PM2.5 actuel</div>
         <div class="flex items-center gap-2">
           <div id="kpi-last" class="text-3xl font-semibold tabular-nums text-text">–</div>
           <span id="kpi-last-arrow" class="text-3xl"></span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -89,7 +89,7 @@
 
       <div class="card kpi-card md:col-span-4">
         <div class="kpi-header">
-          <p class="kpi-label">PM₂.₅ actuel</p>
+          <p class="kpi-label">PM2.5 actuel</p>
           <span class="kpi-icon" aria-hidden="true">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
               <path d="M5 16.5a7 7 0 1 1 14 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>

--- a/docs/main.js
+++ b/docs/main.js
@@ -5,7 +5,6 @@ function getThemeColors() {
     return {
       pm25: '#FDCA40',
       pm10: '#811EEB',
-      pm1: '#0047AB',
       grid: '#D9E0EE',
       text: '#080708',
       panel: '#FFFFFF'
@@ -21,7 +20,6 @@ function getThemeColors() {
   return {
     pm25: read('--chart-pm25', read('--warning', '#FDCA40')),
     pm10: read('--chart-pm10', read('--secondary', '#811EEB')),
-    pm1: read('--chart-pm1', '#0047AB'),
     grid: read('--border', '#D9E0EE'),
     text: read('--text', '#080708'),
     panel: read('--panel', '#FFFFFF')
@@ -118,7 +116,7 @@ async function series(startISO, endISO) {
         const to = Math.min(total - 1, from + pageSize - 1);
         const { data, error } = await sb
           .from('readings')
-          .select('ts, pm1, pm25, pm10')
+          .select('ts, pm25, pm10')
           .gte('ts', startISO)
           .lte('ts', endISO)
           .order('ts', { ascending: true })
@@ -243,7 +241,7 @@ function renderSummary(id, serie) {
   const above = serie.filter(r => (r.pm25 ?? 0) > WHO_LINE).length;
   const max25 = Math.max(...serie.map(r => r.pm25 ?? 0));
   wrap.appendChild(chip(`Pics au-dessus du seuil : ${above}`));
-  wrap.appendChild(chip(`PM₂.₅ maximum : ${Math.round(max25)} µg/m³`));
+  wrap.appendChild(chip(`PM2.5 maximum : ${Math.round(max25)} µg/m³`));
 }
 
 function updateKpiCards(stats) {
@@ -278,17 +276,15 @@ function plotOne(containerId, serie, title, xRange) {
     const ts = r.ts || r.t || r.time || r.date || r['ts'];
     return dayjs(ts).tz('Europe/Paris').format();
   });
-  const y1 = serie.map(r => r.pm1  != null ? Math.round(r.pm1)  : null);
   const y25= serie.map(r => r.pm25 != null ? Math.round(r.pm25) : null);
   const y10= serie.map(r => r.pm10 != null ? Math.round(r.pm10) : null);
 
   const traces = [
-    { name:'PM₂.₅', x, y: y25, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm25 } },
-    { name:'PM₁₀',  x, y: y10, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm10 } },
-    { name:'PM₁',   x, y: y1,  mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm1  } },
+    { name:'PM2.5', x, y: y25, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm25 } },
+    { name:'PM10',  x, y: y10, mode:'lines', type:'scatter', line:{ width:4, color:COLORS.pm10 } },
   ];
 
-  const allVals = [...y1, ...y25, ...y10].filter(v => v != null);
+  const allVals = [...y25, ...y10].filter(v => v != null);
   const ymax = allVals.length
     ? Math.max(WHO_LINE, Math.ceil(Math.max(...allVals) / 5) * 5)
     : WHO_LINE;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -22,7 +22,6 @@
   --danger-rgb: 223, 41, 53;
   --chart-pm25: #FDCA40;
   --chart-pm10: #811EEB;
-  --chart-pm1: #0047AB;
   --shadow-soft: 0 24px 48px -32px rgba(8, 7, 8, 0.18);
   --display-font: 'Bricolage Grotesque', 'Inter', 'Helvetica Neue', Arial, sans-serif;
   --body-font: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
@@ -237,9 +236,9 @@ h3 {
 }
 
 .kpi-label {
-  font-size: 0.75rem;
+  font-size: 0.9rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   color: var(--caption);
   font-family: var(--display-font);
   text-transform: uppercase;
@@ -308,15 +307,15 @@ h3 {
 }
 
 .kpi-unit {
-  font-size: 0.75rem;
-  letter-spacing: 0.16em;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
   color: var(--secondary);
   margin-bottom: 8px;
 }
 
 .kpi-sub {
   margin-top: 8px;
-  font-size: 0.75rem;
+  font-size: 0.85rem;
   color: var(--secondary);
   letter-spacing: 0.02em;
 }


### PR DESCRIPTION
## Summary
- remove PM1 traces and labels so only PM2.5 and PM10 are displayed
- rename PM2.5 labels to use standard numerals and update supporting copy
- increase KPI label, unit, and subtitle sizes for better legibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee3302fa08332b8078d999fa28703